### PR TITLE
Update -addr flag help usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example Sensu 2.x handler definition:
 {
   "name": "influx-db",
   "type": "pipe",
-  "command": "sensu-influxdb-handler --addr '123.4.5.6:8086' --username 'foo' --password 'bar' --db-name 'myDB'"
+  "command": "sensu-influxdb-handler --addr 'http://123.4.5.6:8086' --username 'foo' --password 'bar' --db-name 'myDB'"
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func configureRootCommand() *cobra.Command {
 		"addr",
 		"a",
 		"",
-		"the address of the influx-db server")
+		"the address of the influx-db server, should be of the form 'http://host:port'")
 
 	cmd.Flags().StringVarP(&dbName,
 		"db-name",


### PR DESCRIPTION
A Sensu user reported some difficulties while trying to configure the `-addr` flag of this influx handler.

After digging into the influx client code, it seems like a specific format is required: https://github.com/influxdata/influxdb/blob/badc1d8ed3056e46f0855223c500152eae0c5f1f/client/v2/client.go#L25

This PR simply updates the help usage for the `-addr` flag.

I also updated the documentation: https://github.com/sensu/sensu-docs/pull/692