### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Example Sensu 2.x check definition:
     "system"
   ],
   "output_metric_format": "graphite_plaintext",
-  "output_metric_handlers": [influx-db]
+  "output_metric_handlers": ["influx-db"]
 }
 ```
 That's right, you can collect different types of metrics (ex. Graphite), Sensu


### PR DESCRIPTION
Fixing a typo in the check definition example