### PR TITLE
use envvars as default value for sensitive argments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use of envvar by default for sensitive InfluxDB credentials: addr,username, and password. This prevents leaking of sensitive credential into system process table via command argument. This is a backwards compatible change, commandline arguments can still be used to override envvar values. Here is the envvar to argument mapping:
+    - INFLUXDB_ADDR => --addr 
+    - INFLUXDB_USER => --username
+    - INFLUXDB_PASS => --password
+
 
 ## [3.1.0] - 2018-12-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ Example Sensu Go handler definition:
     },
     "spec": {
         "type": "pipe",
-        "command": "sensu-influxdb-handler -a 'http://influxdb.default.svc.cluster.local:8086' -d sensu -u sensu -p password",
+        "command": "sensu-influxdb-handler -d sensu",
         "timeout": 10,
+        "env_vars": [
+            "INFLUXDB_ADDR=http://influxdb.default.svc.cluster.local:8086",
+            "INFLUXDB_USER=sensu",
+            "INFLUXDB_PASS=password"
+        ],
         "filters": [
             "has_metrics"
         ]
@@ -72,6 +77,10 @@ That's right, you can collect different types of metrics (ex. Influx,
 Graphite, OpenTSDB, Nagios, etc.), Sensu will extract and transform
 them, and this handler will populate them into your InfluxDB.
 
+**Security Note:** The InfluxDB addr, username and password are treated as a security sensitive configuration options in this example and are loaded into the handler config as an env_vars instead of as a command arguments. Command arguments are commonaly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files as part of command execution. The command flags for these configuration options are are provided as an override for testing purposes.
+
+
+
 ## Usage Examples
 
 Help:
@@ -80,13 +89,14 @@ Usage:
   sensu-influxdb-handler [flags]
 
 Flags:
-  -a, --addr string            the address of the influxdb server, should be of the form 'http://host:port'
+  -a, --addr string            the address of the influxdb server, should be of the form 'http://host:port', defaults to value of INFLUXDB_ADDR env variable
   -d, --db-name string         the influxdb to send metrics to
   -h, --help                   help for sensu-influxdb-handler
   -i, --insecure-skip-verify   if true, the influx client skips https certificate verification
-  -p, --password string        the password for the given db
+  -p, --password string        the password for the given db, defaults to value of INFLUXDB_PASS env variable
       --precision string       the precision value of the metric (default "s")
-  -u, --username string        the username for the given db
+  -u, --username string        the username for the given db, defaults to value of INFLUXDB_USER env variable
+
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ That's right, you can collect different types of metrics (ex. Influx,
 Graphite, OpenTSDB, Nagios, etc.), Sensu will extract and transform
 them, and this handler will populate them into your InfluxDB.
 
-**Security Note:** The InfluxDB addr, username and password are treated as a security sensitive configuration options in this example and are loaded into the handler config as an env_vars instead of as a command arguments. Command arguments are commonaly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files as part of command execution. The command flags for these configuration options are are provided as an override for testing purposes.
+**Security Note:** The InfluxDB addr, username and password are treated as a security sensitive configuration options in this example and are loaded into the handler config as env_vars instead of as a command arguments. Command arguments are commonly readable from the process table by other unprivaledged users on a system (ex: `ps` and `top` commands), so it's a better practise to read in sensitive information via environment variables or configuration files as part of command execution. The command flags for these configuration options are provided as an override for testing purposes.
 
 
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,6 @@ func configureRootCommand() *cobra.Command {
 		false,
 		"if true, the influx client skips https certificate verification")
 
-	/* Cannot mark envvar backed arguments as required, must manually check */
 	_ = cmd.MarkFlagRequired("db-name")
 
 	return cmd


### PR DESCRIPTION
Treat influx addr, username and password as sensitive credentials.

It's preferable to read sensitive information from envvars.
commandline arguments can be read from the process table for ex: `ps -aux`

Solution in this PR:
1. Use os.Getenv() to retrieve default values from env vars  when constructing command flags.
2. Do not mark these as required flags, if not set and env var defaults are used.
3. Manual test for empty string values and error out accordingly.