### PR TITLE
Don't unnecessarily require configuration vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Username and password are no longer required to be set, making it possible to connect to endpoints that do not have authentication enabled.
+
 ### Changed
 - Updated travis, goreleaser configurations.
 - Updated license.
+- If no endpoint addr is provided, the handler will default to http://localhost:8086/
 
 ### Removed
 - Removed redundant post deploy scripts for travis.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Usage:
   sensu-influxdb-handler [flags]
 
 Flags:
-  -a, --addr string            the address of the influxdb server, should be of the form 'http://host:port', defaults to value of INFLUXDB_ADDR env variable
+  -a, --addr string            the address of the influxdb server, should be of the form 'http://host:port', defaults to 'http://localhost:8086' or value of INFLUXDB_ADDR env variable
   -d, --db-name string         the influxdb to send metrics to
   -h, --help                   help for sensu-influxdb-handler
   -i, --insecure-skip-verify   if true, the influx client skips https certificate verification

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func configureRootCommand() *cobra.Command {
 		"addr",
 		"a",
 		os.Getenv("INFLUXDB_ADDR"),
-		"the address of the influxdb server, should be of the form 'http://host:port', defaults to value of INFLUXDB_ADDR env variable")
+		"the address of the influxdb server, should be of the form 'http://host:port', defaults to 'http://localhost:8086' or value of INFLUXDB_ADDR env variable")
 
 	cmd.Flags().StringVarP(&username,
 		"username",
@@ -92,18 +92,8 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid argument(s) received")
 	}
 
-	/* Manually check security sensitive arguments */
 	if addr == "" {
-		_ = cmd.Help()
-		return fmt.Errorf("Influxdb addr not set")
-	}
-	if password == "" {
-		_ = cmd.Help()
-		return fmt.Errorf("Influxdb user password not set")
-	}
-	if username == "" {
-		_ = cmd.Help()
-		return fmt.Errorf("Influxdb username not set")
+		addr = "http://localhost:8086"
 	}
 
 	if stdin == nil {


### PR DESCRIPTION
InfluxDB connections do not always require a username and password, and we can default to connecting to the default port on localhost (matching the behaviour of the `influx` CLI tool.)

Fixes #23