### PR TITLE
Change how Travis setups and runs goreleaser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,14 @@ script:
 before_script:
 - echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
-before_deploy:
-- go get github.com/goreleaser/goreleaser
-
 deploy:
   - #goreleaser
     provider: script
-    script: goreleaser
+    script: curl -sL https://git.io/goreleaser | bash
     skip_cleanup: true
     on:
       tags: true
+      condition: $TRAVIS_OS_NAME = linux
 
 after_deploy:
   - git clone https://github.com/sensu/sensu-go-bonsai-asset.git bonsai


### PR DESCRIPTION
This change is based off the goreleaser manual, see https://goreleaser.com/ci/

While trying to make a new release (3.1.2), Travis' deployment part that uses goreleaser stopped working; the `go get github.com/goreleaser/goreleaser` command would always fail. This PR changes the way we setup and run goreleaser, based off the goreleaser manual.

The change has been tested by creating a temporary tag (since deleted) to force Travis to run a deployment of this branch. goreleaser was successfully installed and run until it complained that the tag name did not respect semantic versioning. I'm expecting it will just work once I try a proper release with this PR merged.

Before: https://travis-ci.org/sensu/sensu-influxdb-handler/builds/496695795
After: https://travis-ci.org/sensu/sensu-influxdb-handler/builds/496827401

A similar change probably needs to be applied on _all_ our `.travis.yml` files.