### PR TITLE
update testing of Execute to use non-default exitFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed testing to fully test handler's Execute function using a non-default exitFunction instead of os.Exit
 
 ## [3.3.0] - 2020-06-11
 ### Changed


### PR DESCRIPTION
Due to the way the plugin sdk operates, the handler's Execute function will call `os.Exit` by default as part of `Execute()` 

This makes it impossible to test state after `Execute()` is called from `main()` in the test used  in `TestMain`.

I've addressed this by changing the testing structure tp test Execute explicitly and setting a non-default exitFunction to capture the exit status integer instead of calling os.Exit

previous TestMain never actually reached the `assert.True(requestReceived)` statement because `main()` was calling `os.Exit` 